### PR TITLE
logstash/database/request-event: ignore timestamps in the future

### DIFF
--- a/logstash/pipelines/devops/database/request-event.conf
+++ b/logstash/pipelines/devops/database/request-event.conf
@@ -27,7 +27,7 @@ input {
                 request_event_details   = re.[EVENTDETAILS]
             FROM
                 [dbo].[oslog_RequestEvent] (nolock) re
-            WHERE DATEDIFF(SECOND,'2021-01-01', instant) > :sql_last_value
+            WHERE DATEDIFF(SECOND,'2021-01-01', instant) > :sql_last_value AND instant < getutcdate()
         "
     }
 }


### PR DESCRIPTION
The request event table contains events from both client and server.
The client events use the timestamp of the client. If the client's
system clock is misconfigured, this could be a timestamp far in the
future.

After logstash ingests this event, it will save :sql_last_value to be
far in the future and thereafter stop ingesting any more events until
that future date is reached.

As a quick fix, we can filter out data with timestamps in the future.
There will still be minor inconsistencies, but this will at least
make sure that logstash doesn't stop ingesting data from this table
entirely for weeks on end.

Note: I haven't verified if getutcdate() is available on all outsystems
supported database backends.