### PR TITLE
Http metadata removal

### DIFF
--- a/data_extraction/logstash/pipelines/devops/monitor-probe/error.conf
+++ b/data_extraction/logstash/pipelines/devops/monitor-probe/error.conf
@@ -36,7 +36,7 @@ filter {
             "[log][data_source]" => "Error"
         }
 
-        remove_field => [ "name", "cycle" ]
+        remove_field => [ "name", "cycle", "http_poller_metadata" ]
 
         rename => {
             "instant" => "[log][instant]"

--- a/data_extraction/logstash/pipelines/devops/monitor-probe/extension.conf
+++ b/data_extraction/logstash/pipelines/devops/monitor-probe/extension.conf
@@ -35,7 +35,7 @@ filter {
             "[log][data_source]" => "Extension"
         }
 
-        remove_field => [ "name", "cycle" ]
+        remove_field => [ "name", "cycle", "http_poller_metadata" ]
 
         rename => {
             "instant" => "[log][instant]"

--- a/data_extraction/logstash/pipelines/devops/monitor-probe/general.conf
+++ b/data_extraction/logstash/pipelines/devops/monitor-probe/general.conf
@@ -41,7 +41,7 @@ filter {
             "[log][data_source]" => "General"
         }
 
-        remove_field => [ "name", "cycle" ]
+        remove_field => [ "name", "cycle", "http_poller_metadata" ]
 
         rename => {
             "instant" => "[log][instant]"

--- a/data_extraction/logstash/pipelines/devops/monitor-probe/integration.conf
+++ b/data_extraction/logstash/pipelines/devops/monitor-probe/integration.conf
@@ -35,7 +35,7 @@ filter {
             "[log][data_source]" => "Integration"
         }
 
-        remove_field => [ "name", "cycle" ]
+        remove_field => [ "name", "cycle", "http_poller_metadata" ]
 
         rename => {
             "instant" => "[log][instant]"

--- a/data_extraction/logstash/pipelines/devops/monitor-probe/mobile-request.conf
+++ b/data_extraction/logstash/pipelines/devops/monitor-probe/mobile-request.conf
@@ -35,7 +35,7 @@ filter {
             "[log][data_source]" => "Mobile Request"
         }
 
-        remove_field => [ "name", "cycle" ]
+        remove_field => [ "name", "cycle", "http_poller_metadata" ]
 
         rename => {
             "instant" => "[log][instant]"

--- a/data_extraction/logstash/pipelines/devops/monitor-probe/request-event.conf
+++ b/data_extraction/logstash/pipelines/devops/monitor-probe/request-event.conf
@@ -35,7 +35,7 @@ filter {
             "[log][data_source]" => "Request Event"
         }
 
-        remove_field => [ "name", "cycle" ]
+        remove_field => [ "name", "cycle", "http_poller_metadata" ]
 
         copy => { "eventdetails" => "[log][raw_details]" }
 

--- a/data_extraction/logstash/pipelines/devops/monitor-probe/timer.conf
+++ b/data_extraction/logstash/pipelines/devops/monitor-probe/timer.conf
@@ -35,7 +35,7 @@ filter {
             "[log][data_source]" => "Timer"
         }
 
-        remove_field => [ "name", "cycle" ]
+        remove_field => [ "name", "cycle", "http_poller_metadata" ]
 
         rename => {
             "instant" => "[log][instant]"

--- a/data_extraction/logstash/pipelines/devops/monitor-probe/web-request.conf
+++ b/data_extraction/logstash/pipelines/devops/monitor-probe/web-request.conf
@@ -35,7 +35,7 @@ filter {
             "[log][data_source]" => "Web Request"
         }
 
-        remove_field => [ "name", "cycle" ]
+        remove_field => [ "name", "cycle", "http_poller_metadata" ]
 
         rename => {
             "instant" => "[log][instant]"


### PR DESCRIPTION
Http poller metadata can pass MonitorProbe auth user/pwd in the clear to elasticsearch documents. This removes that metadata.