### PR TITLE
Improve ElasticSetup to properly depend on Elastic

### DIFF
--- a/docker-demo/docker-compose.yml
+++ b/docker-demo/docker-compose.yml
@@ -22,6 +22,9 @@ services:
         hard: -1
     healthcheck:
       test: ["CMD", "curl","-s" ,"-f", "http://localhost:9200/_cat/health"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
     networks:
       - elasticnetwork
 
@@ -35,7 +38,8 @@ services:
       - ./elasticsearch/config/transform.json:/transform.json
       - ./elasticsearch/config/index_bootstrap.json:/index_bootstrap.json
     depends_on:
-      - elasticsearch
+      elasticsearch:
+        condition: service_healthy
     networks:
       - elasticnetwork
     command: sh ./setup.sh


### PR DESCRIPTION
Added retries to the health checks of the ElasticSearch Container
Made the ElasticSearch-Setup container depend on the healthy status of the ElasticSearch Container

This should solve the issue of having to manually run the ElasticSearch-Setup container manually.